### PR TITLE
Bump up next version. Fix the dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@next/font": "^13.0.5",
     "eslint": "8.27.0",
-    "eslint-config-next": "13.0.2",
-    "next": "13.0.2",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "eslint-config-next": "^13.4.10",
+    "next": "^13.4.10",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
While running the app by
`yarn dev`
it gives error:
`Font loader error: Cannot find module 'next/dist/compiled/https-proxy-agent'`

By upgrading to latest version of nextjs, it works